### PR TITLE
fix(grammar): allow parameter-less function declarations

### DIFF
--- a/src/flex/Moon.bnf
+++ b/src/flex/Moon.bnf
@@ -137,8 +137,8 @@ let-statement ::= modifier? KW_LET KW_MUTABLE? identifier type-hint? OP_ASSIGN t
 //    mixin = "com.github.bytecodealliance.language.mixin.MixinWorld"
 }
 // =====================================================================================================================
-declare-function ::= modifier* function-extern? KW_FN function-name declare-generic? declare-parameters return-type? (function-body | function-inline) {
-	pin = 4
+declare-function ::= modifier* function-extern? KW_FN function-name declare-generic? declare-parameters? return-type? (function-body | function-inline) {
+	pin = 3
 //    mixin = "com.github.bytecodealliance.language.mixin.MixinInterface"
 }
 function-name   ::= (identifier-free NAME_JOIN)? identifier-free


### PR DESCRIPTION
## Summary
- Make `declare-parameters` optional (`declare-parameters?`) in `Moon.bnf` so that modern MoonBit syntax like `fn main { ... }` (without parentheses) parses correctly
- Change pin from 4 to 3 so the parser commits on `KW_FN` rather than after matching parameters that may be absent

## Problem
The current grammar requires parentheses on all function declarations. Opening a file containing `fn main {` produces:

```
MoonLeaf.(, MoonLeaf.NAME_JOIN or MoonLeaf.[ expected, got '{'
```

## Note
The generated parser files under `src/main/gen/` need to be regenerated with Grammar-Kit after merging this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)